### PR TITLE
Updates to CLI for downloading ERA5 data

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,14 +1,10 @@
 [era5-download]
 # path of the ERA5 dataset, default is the 0.25deg analysis-ready dataset on Google Cloud
 source_path = "gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2"
-# start date of the data to download
-start_date = "2019-01-01"
-# start time of the data to download
-start_time = "00:00:00"
-# end date of the data to download
-end_date = "2019-01-02"
-# end time of the data to download
-end_time = "00:00:00"
+# start datetime of the data to download, following ISO 8601 format
+start_datetime = "2019-01-01T00"
+# end datetime of the data to download, following ISO 8601 format
+end_datetime = "2019-01-02T00"
 
 # Delta time between samples
 delta_time = "1h"

--- a/config.ini
+++ b/config.ini
@@ -1,9 +1,9 @@
 [era5-download]
 # path of the ERA5 dataset, default is the 0.25deg analysis-ready dataset on Google Cloud
 source_path = "gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2"
-# start datetime of the data to download, following ISO 8601 format
+# start datetime of the data to download, following ISO 8601 format: "YYYY-MM-DDTHH"
 start_datetime = "2019-01-01T00"
-# end datetime of the data to download, following ISO 8601 format
+# end datetime of the data to download, following ISO 8601 format: "YYYY-MM-DDTHH"
 end_datetime = "2019-01-02T00"
 
 # Delta time between samples

--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,7 @@ source_path = "gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-ch
 # start datetime of the data to download, following ISO 8601 format: "YYYY-MM-DDTHH"
 start_datetime = "2019-01-01T00"
 # end datetime of the data to download, following ISO 8601 format: "YYYY-MM-DDTHH"
-end_datetime = "2019-01-02T00"
+end_datetime = "2019-01-05T00"
 
 # Delta time between samples
 delta_time = "1h"
@@ -22,7 +22,7 @@ delta_time = "1h"
 # delta_time = "12m" 1 sample every year
 
 # What variables to download
-variables = "all"
+variables = "temperature"
 # This supports "all" or a comma separated list of variables:
 #   - "all"
 #   - "temperature_2m"

--- a/config.ini
+++ b/config.ini
@@ -39,6 +39,7 @@ levels = "1000"
 # Available levels:
 # - 1000/975/950/925/900/875/850/825/800/775/750/700/650/600/550/500/450/400/350/300/250/225/200/175/150/125/100/70/50/30/20/10/7/5/3/2/1
 
+# File name to save the downloaded ERA5 dataset. It will be saved to `data/era5_download/`.
 save_name = ""
 # If left empty, the file will be saved with the following format:
-# - "{start_date}_{end_date}_{delta_time}.nc"
+# - "{start_datetime}_{end_datetime}_{delta_time}.nc"

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!.gitkeep
+!*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
 dependencies = ["xarray",
     "netCDF4",
     "zarr",
+    "fsspec",
+    "gcsfs",
     "pyprojroot"]
 
 [project.optional-dependencies]

--- a/src/dmd_era5/era5_download/create_mock_era5.py
+++ b/src/dmd_era5/era5_download/create_mock_era5.py
@@ -8,11 +8,10 @@ def create_mock_era5(start_datetime, end_datetime, variables, levels):
     Create a mock ERA5-like dataset for testing purposes.
 
     Args:
-        start_datetime (str):
-            Start date in 'YYYY-MM-DDTHH:MM' format, e.g. '2020-01-01' or
-            '2020-01-01T00'
-        end_datetime (str):
-            End date in 'YYYY-MM-DDTHH' format, e.g. '2020-01-02' or '2020-01-02T23'
+        start_datetime (str or datetime-like):
+            Start datetime of the dataset, e.g. "2020-01-01T06"
+        end_datetime (str or datetime-like):
+            End datetime of the dataset, e.g. ""2020-01-05"
         variables (list): List of variable names
         levels (list): List of pressure levels
 

--- a/src/dmd_era5/era5_download/create_mock_era5.py
+++ b/src/dmd_era5/era5_download/create_mock_era5.py
@@ -3,13 +3,16 @@ import pandas as pd
 import xarray as xr
 
 
-def create_mock_era5(start_date, end_date, variables, levels):
+def create_mock_era5(start_datetime, end_datetime, variables, levels):
     """
     Create a mock ERA5-like dataset for testing purposes.
 
     Args:
-        start_date (str): Start date in 'YYYY-MM-DD' format
-        end_date (str): End date in 'YYYY-MM-DD' format
+        start_datetime (str):
+            Start date in 'YYYY-MM-DDTHH:MM' format, e.g. '2020-01-01' or
+            '2020-01-01T00'
+        end_datetime (str):
+            End date in 'YYYY-MM-DDTHH' format, e.g. '2020-01-02' or '2020-01-02T23'
         variables (list): List of variable names
         levels (list): List of pressure levels
 
@@ -17,7 +20,7 @@ def create_mock_era5(start_date, end_date, variables, levels):
         xr.Dataset: A mock ERA5-like dataset
     """
     # Create time range
-    times = pd.date_range(start=start_date, end=end_date, freq="h")
+    times = pd.date_range(start=start_datetime, end=end_datetime, freq="h")
 
     # Create latitude and longitude ranges (reduced resolution for testing)
     lats = np.arange(90, -90, -5)

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -262,8 +262,8 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         if use_mock_data:
             log_and_print(logger, "Creating mock ERA5 data...")
             full_era5_ds = create_mock_era5(
-                start_date=parsed_config["start_date"].strftime("%Y-%m-%d"),
-                end_date=parsed_config["end_date"].strftime("%Y-%m-%d"),
+                start_datetime=parsed_config["start_date"].strftime("%Y-%m-%d"),
+                end_datetime=parsed_config["end_date"].strftime("%Y-%m-%d"),
                 variables=parsed_config["variables"]
                 if parsed_config["variables"] != ["all"]
                 else ["temperature", "u_component_of_wind", "v_component_of_wind"],

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -225,8 +225,8 @@ def add_config_attributes(ds: xr.Dataset, parsed_config: dict) -> xr.Dataset:
         xr.Dataset: The ERA5 dataset with the configuration settings as attributes.
     """
     ds.attrs["source_path"] = parsed_config["source_path"]
-    ds.attrs["start_date"] = parsed_config["start_date"].strftime("%Y-%m-%d")
-    ds.attrs["end_date"] = parsed_config["end_date"].strftime("%Y-%m-%d")
+    ds.attrs["start_datetime"] = parsed_config["start_datetime"].isoformat()
+    ds.attrs["end_datetime"] = parsed_config["end_datetime"].isoformat()
     ds.attrs["delta_time"] = parsed_config["delta_time"]
     ds.attrs["variables"] = parsed_config["variables"]
     ds.attrs["levels"] = parsed_config["levels"]
@@ -250,8 +250,8 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         if use_mock_data:
             log_and_print(logger, "Creating mock ERA5 data...")
             full_era5_ds = create_mock_era5(
-                start_datetime=parsed_config["start_date"].strftime("%Y-%m-%d"),
-                end_datetime=parsed_config["end_date"].strftime("%Y-%m-%d"),
+                start_datetime=parsed_config["start_datetime"],
+                end_datetime=parsed_config["end_datetime"],
                 variables=parsed_config["variables"]
                 if parsed_config["variables"] != ["all"]
                 else ["temperature", "u_component_of_wind", "v_component_of_wind"],
@@ -277,8 +277,8 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         log_and_print(logger, "Slicing ERA5 Dataset...")
         era5_ds = slice_era5_dataset(
             full_era5_ds,
-            parsed_config["start_date"],
-            parsed_config["end_date"],
+            parsed_config["start_datetime"],
+            parsed_config["end_datetime"],
             parsed_config["levels"],
         )
 
@@ -301,7 +301,7 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
 
     except Exception as e:
         msg = f"""Error {'creating mock' if use_mock_data else 'opening'}
-        the ERA5 Dataset: {e}"""
+        ERA5 Dataset: {e}"""
         log_and_print(logger, msg, level="error")
         raise ValueError(msg) from e
 

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -30,12 +30,8 @@ def validate_time_parameters(parsed_config: dict) -> None:
         ValueError: If any of the time parameters are invalid or inconsistent.
     """
 
-    start_datetime = datetime.combine(
-        parsed_config["start_date"], parsed_config["start_time"]
-    )
-    end_datetime = datetime.combine(
-        parsed_config["end_date"], parsed_config["end_time"]
-    )
+    start_datetime = parsed_config["start_datetime"]
+    end_datetime = parsed_config["end_datetime"]
     delta_time = parsed_config["delta_time"]
 
     # Check if end datetime is after start datetime
@@ -81,10 +77,8 @@ def config_parser(config: dict = config) -> dict:
     # Validate the required fields
     required_fields = [
         "source_path",
-        "start_date",
-        "start_time",
-        "end_date",
-        "end_time",
+        "start_datetime",
+        "end_datetime",
         "delta_time",
         "variables",
         "levels",
@@ -102,14 +96,11 @@ def config_parser(config: dict = config) -> dict:
 
     # ------------ Parse the start date and time ------------
     try:
-        parsed_config["start_date"] = datetime.strptime(
-            config["start_date"], "%Y-%m-%d"
+        parsed_config["start_datetime"] = datetime.fromisoformat(
+            config["start_datetime"]
         )
-        parsed_config["start_time"] = datetime.strptime(
-            config["start_time"], "%H:%M:%S"
-        ).time()
     except ValueError as e:
-        msg = f"Invalid start date or time format: {e}"
+        msg = f"Invalid start datetime format in config: {e}"
         logger.error(msg)
         raise ValueError(msg) from e
 
@@ -143,12 +134,9 @@ def config_parser(config: dict = config) -> dict:
 
     # ------------ Parse the end date and time ------------
     try:
-        parsed_config["end_date"] = datetime.strptime(config["end_date"], "%Y-%m-%d")
-        parsed_config["end_time"] = datetime.strptime(
-            config["end_time"], "%H:%M:%S"
-        ).time()
+        parsed_config["end_datetime"] = datetime.fromisoformat(config["end_datetime"])
     except ValueError as e:
-        msg = f"Invalid end time or date format in config: {e}"
+        msg = f"Invalid end datetime format in config: {e}"
         logger.error(msg)
         raise ValueError(msg) from e
 
@@ -181,8 +169,8 @@ def config_parser(config: dict = config) -> dict:
         # If left empty, the file will be saved with the following format:
         # - "{start_date}_{end_date}_{delta_time}.nc"
 
-        start_str = parsed_config["start_date"].strftime("%Y-%m-%d")
-        end_str = parsed_config["end_date"].strftime("%Y-%m-%d")
+        start_str = parsed_config["start_datetime"].strftime("%Y-%m-%dT%H")
+        end_str = parsed_config["end_datetime"].strftime("%Y-%m-%dT%H")
         delta_str = config["delta_time"]
         parsed_config["save_name"] = f"{start_str}_{end_str}_{delta_str}.nc"
     else:

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -199,7 +199,8 @@ def slice_era5_dataset(
 
 def thin_era5_dataset(ds: xr.Dataset, delta_time: timedelta) -> xr.Dataset:
     """
-    Thin the ERA5 dataset based on the specified time delta.
+    Thin the ERA5 dataset along the time dimension based
+    on the specified time delta.
 
     Args:
         ds (xr.Dataset): The input ERA5 dataset.
@@ -209,8 +210,7 @@ def thin_era5_dataset(ds: xr.Dataset, delta_time: timedelta) -> xr.Dataset:
         xr.Dataset: The thinned ERA5 dataset.
     """
 
-    thinning_factor = int(delta_time.total_seconds() / 3600)
-    return ds.thin(time=thinning_factor)
+    return ds.resample(time=delta_time).nearest()
 
 
 def add_config_attributes(ds: xr.Dataset, parsed_config: dict) -> xr.Dataset:

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -227,7 +227,7 @@ def add_config_attributes(ds: xr.Dataset, parsed_config: dict) -> xr.Dataset:
     ds.attrs["source_path"] = parsed_config["source_path"]
     ds.attrs["start_datetime"] = parsed_config["start_datetime"].isoformat()
     ds.attrs["end_datetime"] = parsed_config["end_datetime"].isoformat()
-    ds.attrs["delta_time"] = parsed_config["delta_time"]
+    ds.attrs["hours_delta_time"] = parsed_config["delta_time"].total_seconds() / 3600
     ds.attrs["variables"] = parsed_config["variables"]
     ds.attrs["levels"] = parsed_config["levels"]
     ds.attrs["date_downloaded"] = datetime.now().isoformat()

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -292,7 +292,9 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
 
         # Save the dataset as NetCDF
         if not use_mock_data:
-            output_path = os.path.join(here(), "data", parsed_config["save_name"])
+            output_path = os.path.join(
+                here(), "data/era5_download", parsed_config["save_name"]
+            )
             log_and_print(logger, f"Saving ERA5 Dataset to {output_path}...")
             era5_ds.to_netcdf(output_path, format="NETCDF4")
             log_and_print(logger, "ERA5 Dataset saved.")

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -55,7 +55,7 @@ def validate_time_parameters(parsed_config: dict) -> None:
         msg = "delta_time must be positive."
         raise ValueError(msg)
 
-    # Check if start_date is not in the future
+    # Check if start_datetime is not in the future
     if start_datetime > datetime.now():
         msg = "Start date cannot be in the future."
         raise ValueError(msg)
@@ -167,7 +167,7 @@ def config_parser(config: dict = config) -> dict:
     # ------------ Generate save_name if not provided ------------
     if not config.get("save_name"):
         # If left empty, the file will be saved with the following format:
-        # - "{start_date}_{end_date}_{delta_time}.nc"
+        # - "{start_datetime}_{end_datetime}_{delta_time}.nc"
 
         start_str = parsed_config["start_datetime"].strftime("%Y-%m-%dT%H")
         end_str = parsed_config["end_datetime"].strftime("%Y-%m-%dT%H")
@@ -187,9 +187,9 @@ def slice_era5_dataset(
 
     Args:
         ds (xr.Dataset): The input ERA5 dataset.
-        start_date (str): The start datetime for slicing, e.g. '2020-01-01T00'.
-        end_date (str): The end datetime for slicing, e.g. '2020-01-02T23'.
-        levels (List[int]): The pressure levels to select.
+        start_datetime (str): The start datetime for slicing, e.g. '2020-01-01T00'.
+        end_datetime (str): The end datetime for slicing, e.g. '2020-01-02T23'.
+        levels (list): The pressure levels to select.
 
     Returns:
         xr.Dataset: The sliced ERA5 dataset.

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -306,8 +306,9 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         return era5_ds
 
     except Exception as e:
-        msg = f"""Error {'creating mock' if use_mock_data else 'opening'}
-        ERA5 Dataset: {e}"""
+        msg = f"""
+        Error {'creating mock' if use_mock_data else 'downloading'} ERA5 Dataset: {e}
+        """
         log_and_print(logger, msg, level="error")
         raise ValueError(msg) from e
 

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -3,6 +3,7 @@ import os
 import sys
 from datetime import datetime, timedelta
 
+import numpy as np
 import xarray as xr
 from pyprojroot import here
 
@@ -294,6 +295,9 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         if not use_mock_data:
             output_path = os.path.join(
                 here(), "data/era5_download", parsed_config["save_name"]
+            )
+            log_and_print(
+                logger, f"Size of ERA5 Dataset: {np.round(era5_ds.nbytes / 1e6)} MB"
             )
             log_and_print(logger, f"Saving ERA5 Dataset to {output_path}...")
             era5_ds.to_netcdf(output_path, format="NETCDF4")

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -192,21 +192,21 @@ def config_parser(config: dict = config) -> dict:
 
 
 def slice_era5_dataset(
-    ds: xr.Dataset, start_date: datetime, end_date: datetime, levels: list
+    ds: xr.Dataset, start_datetime: str, end_datetime: str, levels: list
 ) -> xr.Dataset:
     """
     Slice the ERA5 dataset based on time range and pressure levels.
 
     Args:
         ds (xr.Dataset): The input ERA5 dataset.
-        start_date (datetime): The start date for slicing.
-        end_date (datetime): The end date for slicing.
+        start_date (str): The start datetime for slicing, e.g. '2020-01-01T00'.
+        end_date (str): The end datetime for slicing, e.g. '2020-01-02T23'.
         levels (List[int]): The pressure levels to select.
 
     Returns:
         xr.Dataset: The sliced ERA5 dataset.
     """
-    return ds.sel(time=slice(start_date, end_date), level=levels)
+    return ds.sel(time=slice(start_datetime, end_datetime), level=levels)
 
 
 def thin_era5_dataset(ds: xr.Dataset, delta_time: timedelta) -> xr.Dataset:

--- a/tests/config_reader/test_config_reader.py
+++ b/tests/config_reader/test_config_reader.py
@@ -109,8 +109,10 @@ def test_actual_config_era5_download_section(actual_config_reader):
     """Test the contents of era5-download section in the actual configuration."""
     config = actual_config_reader("era5-download")
     assert "source_path" in config, "era5-download section should have a source_path"
-    assert "start_date" in config, "era5-download section should have a start_date"
-    assert "end_date" in config, "era5-download section should have an end_date"
+    assert (
+        "start_datetime" in config
+    ), "era5-download section should have a start_datetime"
+    assert "end_datetime" in config, "era5-download section should have an end_datetime"
     assert "delta_time" in config, "era5-download section should have a delta_time"
     assert "variables" in config, "era5-download section should have variables"
 

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -39,11 +39,11 @@ def test_config_parser_basic(base_config):
     assert parsed_config["start_datetime"] == datetime(
         2019, 1, 1
     ), f"""start_datetime should be {datetime(2019, 1, 1, 0, 0)}
-    not {parsed_config['start_date']}"""
+    not {parsed_config['start_datetime']}"""
     assert parsed_config["end_datetime"] == datetime(
         2020, 1, 1
     ), f"""end_datetime should be {datetime(2019, 1, 2, 0, 0)}
-    not {parsed_config['end_date']}"""
+    not {parsed_config['end_datetime']}"""
     assert parsed_config["delta_time"] == timedelta(
         days=365
     ), f"delta_time should be {timedelta(hours=1)} not {parsed_config['delta_time']}"

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -228,8 +228,8 @@ def test_download_era5_data_mock(base_config):
 def test_slice_era5_dataset():
     """Test that the slice_era5_dataset function correctly slices the dataset."""
     mock_ds = create_mock_era5(
-        start_datetime="2019-01-01",
-        end_datetime="2019-01-05",
+        start_datetime="2019-01-01T00:00",
+        end_datetime="2019-01-05T00:00",
         variables=["temperature"],
         levels=[1000, 850, 500],
     )
@@ -237,17 +237,17 @@ def test_slice_era5_dataset():
     # Test slicing
     sliced_ds = slice_era5_dataset(
         mock_ds,
-        start_date=datetime(2019, 1, 2),
-        end_date=datetime(2019, 1, 4),
+        start_datetime="2019-01-02T06:00",
+        end_datetime="2019-01-04T23:00",
         levels=[1000, 500],
     )
 
     assert sliced_ds.time.min().values.astype("datetime64[us]").astype(
         datetime
-    ) == datetime(2019, 1, 2)
+    ) == datetime(2019, 1, 2, 6)
     assert sliced_ds.time.max().values.astype("datetime64[us]").astype(
         datetime
-    ) == datetime(2019, 1, 4)
+    ) == datetime(2019, 1, 4, 23)
     assert list(sliced_ds.level.values) == [1000, 500]
 
 

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -81,19 +81,19 @@ def test_config_parser_missing_field(base_config, field):
         config_parser(base_config)
 
 
-# --- Invalid date
+# --- Invalid datetime
 @pytest.mark.parametrize(
-    ("date_field", "invalid_date"),
+    ("datetime_field", "invalid_datetime"),
     [
-        ("start_date", "2019-02-31"),
-        ("start_date", "2019-13-01"),
-        ("start_date", "not-a-date"),
+        ("start_datetime", "2019-02-31"),
+        ("start_datetime", "2019-13-01"),
+        ("start_datetime", "2019-01-01T25"),
     ],
 )
-def test_config_parser_invalid_date(base_config, date_field, invalid_date):
-    """Test the invalid date error."""
-    base_config[date_field] = invalid_date
-    with pytest.raises(ValueError, match="Invalid start date or time format"):
+def test_config_parser_invalid_datetime(base_config, datetime_field, invalid_datetime):
+    """Test the invalid datetime error."""
+    base_config[datetime_field] = invalid_datetime
+    with pytest.raises(ValueError, match="Invalid start"):
         config_parser(base_config)
 
 

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -20,10 +20,8 @@ from dmd_era5.era5_download import (
 def base_config():
     return {
         "source_path": "gs://gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2",
-        "start_date": "2019-01-01",
-        "start_time": "00:00:00",
-        "end_date": "2020-01-01",
-        "end_time": "00:00:01",
+        "start_datetime": "2019-01-01T00",
+        "end_datetime": "2020-01-01T00",
         "delta_time": "1y",
         "variables": "all",
         "levels": "1000",
@@ -38,13 +36,13 @@ def test_config_parser_basic(base_config):
         parsed_config["source_path"] == base_config["source_path"]
     ), f"""source_path should be {base_config['source_path']}
     not {parsed_config['source_path']}"""
-    assert parsed_config["start_date"] == datetime(
+    assert parsed_config["start_datetime"] == datetime(
         2019, 1, 1
-    ), f"""start_date should be {datetime(2019, 1, 1, 0, 0)}
+    ), f"""start_datetime should be {datetime(2019, 1, 1, 0, 0)}
     not {parsed_config['start_date']}"""
-    assert parsed_config["end_date"] == datetime(
+    assert parsed_config["end_datetime"] == datetime(
         2020, 1, 1
-    ), f"""end_date should be {datetime(2019, 1, 2, 0, 0)}
+    ), f"""end_datetime should be {datetime(2019, 1, 2, 0, 0)}
     not {parsed_config['end_date']}"""
     assert parsed_config["delta_time"] == timedelta(
         days=365
@@ -56,8 +54,8 @@ def test_config_parser_basic(base_config):
         1000
     ], f"levels should be [1000] not {parsed_config['levels']}"
     assert (
-        parsed_config["save_name"] == "2019-01-01_2020-01-01_1y.nc"
-    ), f"""save_name should be 2019-01-01_2020-01-01_1y.nc
+        parsed_config["save_name"] == "2019-01-01T00_2020-01-01T00_1y.nc"
+    ), f"""save_name should be 2019-01-01T00_2020-01-01T00_1y.nc
     not {parsed_config['save_name']}"""
 
 

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -97,22 +97,6 @@ def test_config_parser_invalid_datetime(base_config, datetime_field, invalid_dat
         config_parser(base_config)
 
 
-# --- Invalid time
-@pytest.mark.parametrize(
-    ("time_field", "invalid_time"),
-    [
-        ("start_time", "25:00:00"),
-        ("start_time", "12:60:00"),
-        ("start_time", "not-a-time"),
-    ],
-)
-def test_config_parser_invalid_time(base_config, time_field, invalid_time):
-    """Test the invalid time error."""
-    base_config[time_field] = invalid_time
-    with pytest.raises(ValueError, match="Invalid start date or time format"):
-        config_parser(base_config)
-
-
 @pytest.mark.parametrize(
     ("levels", "expected"),
     [

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -173,13 +173,13 @@ def test_config_parser_custom_save_name(base_config, save_name):
 def test_config_parser_generate_save_name(base_config):
     """Test that the save_name is correctly generated when left blank."""
     base_config["save_name"] = ""  # Set save_name to an empty string
-    base_config["start_date"] = "2023-01-01"
-    base_config["end_date"] = "2023-12-31"
+    base_config["start_datetime"] = "2023-01-01"
+    base_config["end_datetime"] = "2023-12-31"
     base_config["delta_time"] = "1d"
 
     parsed_config = config_parser(base_config)
 
-    expected_save_name = "2023-01-01_2023-12-31_1d.nc"
+    expected_save_name = "2023-01-01T00_2023-12-31T00_1d.nc"
     assert (
         parsed_config["save_name"] == expected_save_name
     ), f"""Expected save_name to be {expected_save_name},

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -256,8 +256,8 @@ def test_download_era5_data_mock_with_slicing_and_thinning(base_config):
     Test the full pipeline of downloading, slicing, and
     thinning ERA5 data using a mock dataset.
     """
-    base_config["start_date"] = "2019-01-01"
-    base_config["end_date"] = "2019-01-05"
+    base_config["start_datetime"] = "2019-01-01T06"
+    base_config["end_datetime"] = "2019-01-05T18"
     base_config["delta_time"] = "6h"
     base_config["levels"] = "1000,500"
     parsed_config = config_parser(base_config)
@@ -266,10 +266,10 @@ def test_download_era5_data_mock_with_slicing_and_thinning(base_config):
 
     assert era5_data.time.min().values.astype("datetime64[us]").astype(
         datetime
-    ) == datetime(2019, 1, 1)
+    ) == datetime(2019, 1, 1, 6)
     assert era5_data.time.max().values.astype("datetime64[us]").astype(
         datetime
-    ) == datetime(2019, 1, 5)
+    ) == datetime(2019, 1, 5, 18)
     assert list(era5_data.level.values) == [1000, 500]
     assert (
         era5_data.time.diff("time").astype("timedelta64[ns]").astype(int)

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -67,10 +67,8 @@ def test_config_parser_basic(base_config):
     "field",
     [
         "source_path",
-        "start_date",
-        "start_time",
-        "end_date",
-        "end_time",
+        "start_datetime",
+        "end_datetime",
         "delta_time",
         "variables",
         "levels",

--- a/tests/era5_download/test_era5_download.py
+++ b/tests/era5_download/test_era5_download.py
@@ -228,8 +228,8 @@ def test_download_era5_data_mock(base_config):
 def test_slice_era5_dataset():
     """Test that the slice_era5_dataset function correctly slices the dataset."""
     mock_ds = create_mock_era5(
-        start_date="2019-01-01",
-        end_date="2019-01-05",
+        start_datetime="2019-01-01",
+        end_datetime="2019-01-05",
         variables=["temperature"],
         levels=[1000, 850, 500],
     )
@@ -254,8 +254,8 @@ def test_slice_era5_dataset():
 def test_thin_era5_dataset():
     """Test that the thin_era5_dataset function correctly thins the dataset."""
     mock_ds = create_mock_era5(
-        start_date="2019-01-01",
-        end_date="2019-01-02",
+        start_datetime="2019-01-01",
+        end_datetime="2019-01-02",
         variables=["temperature"],
         levels=[1000],
     )


### PR DESCRIPTION
This pull request includes several updates to the `era5_download` module, focusing on improving the configuration and functionality of datetime handling. The changes include switching from separate date and time fields to a unified datetime format, updating dependencies, and enhancing the test coverage.

### Configuration and Functionality Updates:

* [`config.ini`](diffhunk://#diff-0795adfe01df662f6a34b421a29ee3c5f05389a705da6a791126c6f916701da7L4-R7): Replaced `start_date` and `end_date` with `start_datetime` and `end_datetime`, following ISO 8601 format. Adjusted the `variables` setting to download only temperature data. [[1]](diffhunk://#diff-0795adfe01df662f6a34b421a29ee3c5f05389a705da6a791126c6f916701da7L4-R7) [[2]](diffhunk://#diff-0795adfe01df662f6a34b421a29ee3c5f05389a705da6a791126c6f916701da7L29-R25)
* [`src/dmd_era5/era5_download/era5_download.py`](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L33-R35): Updated various functions to use the new datetime format, including `validate_time_parameters`, `config_parser`, `slice_era5_dataset`, and `download_era5_data`. [[1]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L33-R35) [[2]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L105-R104) [[3]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L195-R204) [[4]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L307-R311)

### Dependency Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R32-R33): Added `fsspec` and `gcsfs` to dependencies to be able to open `zarr` stores with `xarray` and download data from Google Cloud.

### Test Coverage Enhancements:

* [`tests/era5_download/test_era5_download.py`](diffhunk://#diff-43b163ddf77098443d83817e33964b6d2ceb86386ce6abdad1b49721de1d2c82L41-R46): Updated tests to reflect changes in datetime handling and added new tests for invalid datetime formats. [[1]](diffhunk://#diff-43b163ddf77098443d83817e33964b6d2ceb86386ce6abdad1b49721de1d2c82L41-R46) [[2]](diffhunk://#diff-43b163ddf77098443d83817e33964b6d2ceb86386ce6abdad1b49721de1d2c82L88-R96)

### Miscellaneous Changes:

* [`data/.gitignore`](diffhunk://#diff-0406a402f415c90853762eafc928c78b31bb17c9544924f22936a210d937d7d0R1-R4): Updated to ignore all files except `.gitignore` and `.gitkeep`.
* [`src/dmd_era5/era5_download/create_mock_era5.py`](diffhunk://#diff-a7e2917a2474da69e708aaa2f68c64608f39b91f52f6aabb0b43af085437d95bL6-R22): Modified to use the new datetime format for creating mock datasets.

These changes aim to streamline datetime handling in the configuration, improve dependency management, and ensure robust testing.