### PR TITLE
Config parser utils

### DIFF
--- a/src/dmd_era5/__init__.py
+++ b/src/dmd_era5/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+from dmd_era5.config_parser import config_parser
 from dmd_era5.config_reader import config_reader
 from dmd_era5.create_mock_data import create_mock_era5
 from dmd_era5.logger import log_and_print, setup_logger
@@ -23,5 +24,6 @@ __all__ = [
     "slice_era5_dataset",
     "create_mock_era5",
     "standardize_data",
+    "config_parser",
 ]
 __version__ = version(__name__)

--- a/src/dmd_era5/config_parser.py
+++ b/src/dmd_era5/config_parser.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timedelta
+from logging import Logger
+
+
+def validate_time_parameters(parsed_config: dict) -> None:
+    """
+    Validate the time-related parameters in the from the user config.
+
+    Args:
+        parsed_config (dict): The parsed configuration dictionary.
+
+    Raises:
+        ValueError: If any of the time parameters are invalid or inconsistent.
+    """
+
+    start_datetime = parsed_config["start_datetime"]
+    end_datetime = parsed_config["end_datetime"]
+    delta_time = parsed_config["delta_time"]
+
+    # Check if end datetime is after start datetime
+    if end_datetime <= start_datetime:
+        msg = "End datetime must be after start datetime"
+        raise ValueError(msg)
+
+    # Check if the time range is at least as long as delta_time
+    if (end_datetime - start_datetime) < delta_time:
+        msg = f"""Time range must be at least as long as delta_time.
+        {end_datetime} - {start_datetime} < {delta_time}"""
+        raise ValueError(msg)
+
+    # Check if delta_time is positive
+    if delta_time <= timedelta(0):
+        msg = "delta_time must be positive."
+        raise ValueError(msg)
+
+    # Check if start_datetime is not in the future
+    if start_datetime > datetime.now():
+        msg = "Start date cannot be in the future."
+        raise ValueError(msg)
+
+
+def config_parser(config: dict, section: str, logger: Logger | None = None) -> dict:
+    """
+    Parse the configuration dictionary and return a dictionary object.
+
+    Args:
+        config (dict): Configuration dictionary with the configuration parameters.
+        section (str): Section of the configuration file.
+        logger (Logger): Logger object for logging messages. Default is None.
+
+    Returns:
+        dict: Dictionary with the parsed configuration parameters.
+    """
+
+    parsed_config = {}
+
+    if section == "era5-download":
+        required_fields = [
+            "source_path",
+            "start_datetime",
+            "end_datetime",
+            "delta_time",
+            "variables",
+            "levels",
+            "save_name",
+        ]
+    else:
+        msg = f"Section {section} not currently supported."
+        raise ValueError(msg)
+
+    # Check for required fields
+    for field in required_fields:
+        if field not in config:
+            msg = f"Missing required field in config: {field}"
+            if logger is not None:
+                logger.error(msg)
+            raise ValueError(msg)
+
+    # Parse the source path
+    parsed_config["source_path"] = config["source_path"]
+
+    # Parse the start and end datetimes
+    try:
+        parsed_config["start_datetime"] = datetime.fromisoformat(
+            config["start_datetime"]
+        )
+        parsed_config["end_datetime"] = datetime.fromisoformat(config["end_datetime"])
+    except ValueError as e:
+        msg = f"Invalid datetime format in config: {e}"
+        if logger is not None:
+            logger.error(msg)
+        raise ValueError(msg) from e
+
+    # Parse the delta time
+    delta_time_mapping = {
+        "h": lambda x: timedelta(hours=int(x)),
+        "d": lambda x: timedelta(days=int(x)),
+        "w": lambda x: timedelta(weeks=int(x)),
+        "m": lambda x: timedelta(days=int(x) * 365 // 12),
+        "y": lambda x: timedelta(days=int(x) * 365),
+    }
+    try:
+        # Get the unit of the delta time
+        unit = config["delta_time"][-1].lower()
+        # Get the number of units
+        num_units = int(config["delta_time"][:-1])
+        if unit in delta_time_mapping:
+            parsed_config["delta_time"] = delta_time_mapping[unit](num_units)
+        else:
+            msg = f"Unsupported delta_time format in config: {config['delta_time']}"
+            if logger is not None:
+                logger.error(msg)
+            raise ValueError(msg)
+    except ValueError as e:
+        msg = f"Error parsing delta_time from config: {e}"
+        if logger is not None:
+            logger.error(msg)
+        raise ValueError(msg) from e
+
+    # Validate the time parameters
+    validate_time_parameters(parsed_config)
+
+    # Parse the variables
+    try:
+        if config["variables"] == "all":
+            parsed_config["variables"] = ["all"]
+        else:
+            parsed_config["variables"] = [
+                v.strip() for v in config["variables"].split(",")
+            ]
+    except ValueError as e:
+        msg = f"Error parsing variables from config: {e}"
+        if logger is not None:
+            logger.error(msg)
+        raise ValueError(msg) from e
+
+    # Parse the levels
+    try:
+        parsed_config["levels"] = [int(level) for level in config["levels"].split(",")]
+    except ValueError as e:
+        msg = f"Error parsing levels from config: {e}"
+        if logger is not None:
+            logger.error(msg)
+        raise ValueError(msg) from e
+
+    # Generate the save name if not provided
+    if not config.get("save_name"):
+        # If left empty, the file will be saved with the following format:
+        # - "{start_datetime}_{end_datetime}_{delta_time}.nc"
+
+        start_str = parsed_config["start_datetime"].strftime("%Y-%m-%dT%H")
+        end_str = parsed_config["end_datetime"].strftime("%Y-%m-%dT%H")
+        delta_str = config["delta_time"]
+        parsed_config["save_name"] = f"{start_str}_{end_str}_{delta_str}.nc"
+    else:
+        parsed_config["save_name"] = config["save_name"]
+
+    return parsed_config

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -8,6 +8,7 @@ import xarray as xr
 from pyprojroot import here
 
 from dmd_era5 import (
+    config_parser,
     config_reader,
     create_mock_era5,
     log_and_print,
@@ -24,161 +25,6 @@ console_handler.setFormatter(
     logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 )
 logger.addHandler(console_handler)
-
-
-def validate_time_parameters(parsed_config: dict) -> None:
-    """
-    Validate the time-related parameters in the from the user config.
-
-    Args:
-        parsed_config (dict): The parsed configuration dictionary.
-
-    Raises:
-        ValueError: If any of the time parameters are invalid or inconsistent.
-    """
-
-    start_datetime = parsed_config["start_datetime"]
-    end_datetime = parsed_config["end_datetime"]
-    delta_time = parsed_config["delta_time"]
-
-    # Check if end datetime is after start datetime
-    if end_datetime <= start_datetime:
-        msg = "End datetime must be after start datetime"
-        raise ValueError(msg)
-
-    # Check if the time range is at least as long as delta_time
-    if (end_datetime - start_datetime) < delta_time:
-        msg = f"""Time range must be at least as long as delta_time.
-        {end_datetime} - {start_datetime} < {delta_time}"""
-        raise ValueError(msg)
-
-    # Check if delta_time is positive
-    if delta_time <= timedelta(0):
-        msg = "delta_time must be positive."
-        raise ValueError(msg)
-
-    # Check if start_datetime is not in the future
-    if start_datetime > datetime.now():
-        msg = "Start date cannot be in the future."
-        raise ValueError(msg)
-
-
-def config_parser(config: dict = config) -> dict:
-    """
-    Parse the configuration dictionary and return a dictionary object.
-
-    Args:
-        config (dict): Configuration dictionary with the configuration parameters.
-
-    Returns:
-        dict: Dictionary with the parsed configuration parameters.
-    """
-
-    parsed_config = {}
-
-    # Validate the required fields
-    required_fields = [
-        "source_path",
-        "start_datetime",
-        "end_datetime",
-        "delta_time",
-        "variables",
-        "levels",
-        "save_name",
-    ]
-
-    for field in required_fields:
-        if field not in config:
-            msg = f"Missing required field in config: {field}"
-            logger.error(msg)
-            raise ValueError(msg)
-
-    # ------------ Parse the source path ------------
-    parsed_config["source_path"] = config["source_path"]
-
-    # ------------ Parse the start date and time ------------
-    try:
-        parsed_config["start_datetime"] = datetime.fromisoformat(
-            config["start_datetime"]
-        )
-    except ValueError as e:
-        msg = f"Invalid start datetime format in config: {e}"
-        logger.error(msg)
-        raise ValueError(msg) from e
-
-    # ------------ Parse the delta time ------------
-    delta_time_mapping = {
-        "h": lambda x: timedelta(hours=int(x)),
-        "d": lambda x: timedelta(days=int(x)),
-        "w": lambda x: timedelta(weeks=int(x)),
-        "m": lambda x: timedelta(days=int(x) * 365 // 12),
-        "y": lambda x: timedelta(days=int(x) * 365),
-    }
-
-    try:
-        # Get the unit of the delta time
-        unit = config["delta_time"][-1].lower()
-
-        # Get the number of units
-        num_units = int(config["delta_time"][:-1])
-
-        if unit in delta_time_mapping:
-            parsed_config["delta_time"] = delta_time_mapping[unit](num_units)
-        else:
-            msg = f"Unsupported delta_time format in config: {config['delta_time']}"
-            logger.error(msg)
-            raise ValueError(msg)
-
-    except ValueError as e:
-        msg = f"Error parsing delta_time from config: {e}"
-        logger.error(msg)
-        raise ValueError(msg) from e
-
-    # ------------ Parse the end date and time ------------
-    try:
-        parsed_config["end_datetime"] = datetime.fromisoformat(config["end_datetime"])
-    except ValueError as e:
-        msg = f"Invalid end datetime format in config: {e}"
-        logger.error(msg)
-        raise ValueError(msg) from e
-
-    # Validate the time parameters
-    validate_time_parameters(parsed_config)
-
-    # ------------ Parse variables ------------
-    try:
-        if config["variables"] == "all":
-            parsed_config["variables"] = ["all"]
-        else:
-            parsed_config["variables"] = [
-                v.strip() for v in config["variables"].split(",")
-            ]
-    except ValueError as e:
-        msg = f"Error parsing variables from config: {e}"
-        logger.error(msg)
-        raise ValueError(msg) from e
-
-    # ------------ Parse levels ------------
-    try:
-        parsed_config["levels"] = [int(level) for level in config["levels"].split(",")]
-    except ValueError as e:
-        msg = f"Error parsing levels from config: {e}"
-        logger.error(msg)
-        raise ValueError(msg) from e
-
-    # ------------ Generate save_name if not provided ------------
-    if not config.get("save_name"):
-        # If left empty, the file will be saved with the following format:
-        # - "{start_datetime}_{end_datetime}_{delta_time}.nc"
-
-        start_str = parsed_config["start_datetime"].strftime("%Y-%m-%dT%H")
-        end_str = parsed_config["end_datetime"].strftime("%Y-%m-%dT%H")
-        delta_str = config["delta_time"]
-        parsed_config["save_name"] = f"{start_str}_{end_str}_{delta_str}.nc"
-    else:
-        parsed_config["save_name"] = config["save_name"]
-
-    return parsed_config
 
 
 def add_config_attributes(ds: xr.Dataset, parsed_config: dict) -> xr.Dataset:
@@ -283,7 +129,9 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
 def main(use_mock_data: bool = False) -> None:
     """Main function to run the ERA5 download process."""
     try:
-        parsed_config = config_parser()
+        parsed_config = config_parser(
+            config=config, section="era5-download", logger=logger
+        )
         download_era5_data(parsed_config, use_mock_data)
         log_and_print(logger, "ERA5 download process completed successfully.")
     except ValueError as e:

--- a/tests/test_02_era5_download.py
+++ b/tests/test_02_era5_download.py
@@ -7,10 +7,8 @@ from datetime import datetime, timedelta
 import pytest
 import xarray as xr
 
-from dmd_era5.era5_download import (
-    config_parser,
-    download_era5_data,
-)
+from dmd_era5 import config_parser
+from dmd_era5.era5_download import download_era5_data
 
 
 @pytest.fixture
@@ -27,7 +25,7 @@ def base_config():
 
 
 def test_config_parser_basic(base_config):
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
 
     assert (
         parsed_config["source_path"] == base_config["source_path"]
@@ -76,7 +74,7 @@ def test_config_parser_missing_field(base_config, field):
     """Test the missing field error."""
     del base_config[field]
     with pytest.raises(ValueError, match=f"Missing required field in config: {field}"):
-        config_parser(base_config)
+        config_parser(base_config, section="era5-download")
 
 
 # --- Invalid datetime
@@ -91,8 +89,8 @@ def test_config_parser_missing_field(base_config, field):
 def test_config_parser_invalid_datetime(base_config, datetime_field, invalid_datetime):
     """Test the invalid datetime error."""
     base_config[datetime_field] = invalid_datetime
-    with pytest.raises(ValueError, match="Invalid start"):
-        config_parser(base_config)
+    with pytest.raises(ValueError, match="Invalid datetime"):
+        config_parser(base_config, section="era5-download")
 
 
 @pytest.mark.parametrize(
@@ -106,7 +104,7 @@ def test_config_parser_invalid_datetime(base_config, datetime_field, invalid_dat
 def test_config_parser_levels(base_config, levels, expected):
     """Test the levels field."""
     base_config["levels"] = levels
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
     assert (
         parsed_config["levels"] == expected
     ), f"Expected levels to be {expected}, but got {parsed_config['levels']}"
@@ -124,7 +122,7 @@ def test_config_parser_levels(base_config, levels, expected):
 def test_config_parser_delta_time(base_config, delta_time, expected):
     """Test the delta_time field."""
     base_config["delta_time"] = delta_time
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
     assert (
         parsed_config["delta_time"] == expected
     ), f"Expected delta_time to be {expected}, but got {parsed_config['delta_time']}"
@@ -135,7 +133,7 @@ def test_config_parser_invalid_delta_time(base_config, invalid_delta):
     """Test the invalid delta_time error."""
     base_config["delta_time"] = invalid_delta
     with pytest.raises(ValueError, match="Error parsing delta_time"):
-        config_parser(base_config)
+        config_parser(base_config, section="era5-download")
 
 
 @pytest.mark.parametrize(
@@ -149,7 +147,7 @@ def test_config_parser_invalid_delta_time(base_config, invalid_delta):
 def test_config_parser_variables(base_config, variables, expected):
     """Test the variables field."""
     base_config["variables"] = variables
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
     assert (
         parsed_config["variables"] == expected
     ), f"Expected variables to be {expected}, but got {parsed_config['variables']}"
@@ -162,7 +160,7 @@ def test_config_parser_variables(base_config, variables, expected):
 def test_config_parser_custom_save_name(base_config, save_name):
     """Test the custom save_name."""
     base_config["save_name"] = save_name
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
     assert (
         parsed_config["save_name"] == save_name
     ), f"Expected save_name to be {save_name}, but got {parsed_config['save_name']}"
@@ -175,7 +173,7 @@ def test_config_parser_generate_save_name(base_config):
     base_config["end_datetime"] = "2023-12-31"
     base_config["delta_time"] = "1d"
 
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
 
     expected_save_name = "2023-01-01T00_2023-12-31T00_1d.nc"
     assert (
@@ -189,7 +187,7 @@ def test_config_parser_generate_save_name(base_config):
 
 def test_download_era5_data_mock(base_config):
     """Test that the download_era5_data function correctly creates a mock dataset."""
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
 
     # Use the mock dataset
     era5_data = download_era5_data(parsed_config, use_mock_data=True)
@@ -212,7 +210,7 @@ def test_download_era5_data_mock_with_slicing_and_resampling(base_config):
     base_config["end_datetime"] = "2019-01-05T18"
     base_config["delta_time"] = "6h"
     base_config["levels"] = "1000,500"
-    parsed_config = config_parser(base_config)
+    parsed_config = config_parser(base_config, section="era5-download")
 
     era5_data = download_era5_data(parsed_config, use_mock_data=True)
 


### PR DESCRIPTION
This pull request introduces a new `config_parser` function to the `dmd_era5` package, moving the configuration parsing logic from `era5_download.py` to a dedicated module.

Working on `era5_svd`, I realised that much of the configuration parsing logic is the same as in `era5_download`, so it makes sense to create a separate module that can be used across the package.