### PR TITLE
Parse variables and levels

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -23,18 +23,19 @@ delta_time = "1h"
 
 # What variables to download
 variables = "temperature"
-# This supports "all" or a comma separated list of variables:
-#   - "all"
-#   - "temperature_2m"
-#   - "temperature_2m,precipitation"
+# This supports "all_pressure_level_vars", "all_single_level_vars" or a comma separated list of variables:
+# - "temperature"
+# - "u_component_of_wind,v_component_of_wind"
+# - "10m_u_component_of_wind,10m_v_component_of_wind"
+# - "all_pressure_level_vars"
+# - "all_single_level_vars"
+# Note that you cannot mix single level and pressure level variables in the same download
+# Currently supported variables can be found in src/dmd_era5/constants.py
 
-# Available variables here:
-# https://console.cloud.google.com/storage/browser/gcp-public-data-arco-era5/ar/1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2;tab=objects?pli=1&prefix=&forceOnObjectsSortingFiltering=false
-
-# What pressure levels to download
+# What pressure levels to download. Only relevant if downloading pressure level variables.
 levels = "1000"
-# Comma separated list of levels:
+# Comma separated list of levels or "all"
 #  - "1000"
-#  - "1000,1"
-# Available levels:
-# - 1000/975/950/925/900/875/850/825/800/775/750/700/650/600/550/500/450/400/350/300/250/225/200/175/150/125/100/70/50/30/20/10/7/5/3/2/1
+#  - "1000,850"
+#  - "all"
+# Currently supported levels can be found in src/dmd_era5/constants.py

--- a/src/dmd_era5/__init__.py
+++ b/src/dmd_era5/__init__.py
@@ -8,6 +8,11 @@ from importlib.metadata import version
 
 from dmd_era5.config_parser import config_parser
 from dmd_era5.config_reader import config_reader
+from dmd_era5.constants import (
+    ERA5_PRESSURE_LEVEL_VARIABLES,
+    ERA5_SINGLE_LEVEL_VARIABLES,
+    ERA5_VARIABLES,
+)
 from dmd_era5.create_mock_data import create_mock_era5
 from dmd_era5.dvc_tools import add_data_to_dvc, retrieve_data_from_dvc
 from dmd_era5.logger import log_and_print, setup_logger
@@ -28,5 +33,8 @@ __all__ = [
     "config_parser",
     "add_data_to_dvc",
     "retrieve_data_from_dvc",
+    "ERA5_PRESSURE_LEVEL_VARIABLES",
+    "ERA5_SINGLE_LEVEL_VARIABLES",
+    "ERA5_VARIABLES",
 ]
 __version__ = version(__name__)

--- a/src/dmd_era5/__init__.py
+++ b/src/dmd_era5/__init__.py
@@ -10,6 +10,7 @@ from dmd_era5.config_parser import config_parser
 from dmd_era5.config_reader import config_reader
 from dmd_era5.constants import (
     ERA5_PRESSURE_LEVEL_VARIABLES,
+    ERA5_PRESSURE_LEVELS,
     ERA5_SINGLE_LEVEL_VARIABLES,
     ERA5_VARIABLES,
 )
@@ -36,5 +37,6 @@ __all__ = [
     "ERA5_PRESSURE_LEVEL_VARIABLES",
     "ERA5_SINGLE_LEVEL_VARIABLES",
     "ERA5_VARIABLES",
+    "ERA5_PRESSURE_LEVELS",
 ]
 __version__ = version(__name__)

--- a/src/dmd_era5/__init__.py
+++ b/src/dmd_era5/__init__.py
@@ -8,12 +8,6 @@ from importlib.metadata import version
 
 from dmd_era5.config_parser import config_parser
 from dmd_era5.config_reader import config_reader
-from dmd_era5.constants import (
-    ERA5_PRESSURE_LEVEL_VARIABLES,
-    ERA5_PRESSURE_LEVELS,
-    ERA5_SINGLE_LEVEL_VARIABLES,
-    ERA5_VARIABLES,
-)
 from dmd_era5.create_mock_data import create_mock_era5
 from dmd_era5.dvc_tools import add_data_to_dvc, retrieve_data_from_dvc
 from dmd_era5.logger import log_and_print, setup_logger
@@ -34,9 +28,5 @@ __all__ = [
     "config_parser",
     "add_data_to_dvc",
     "retrieve_data_from_dvc",
-    "ERA5_PRESSURE_LEVEL_VARIABLES",
-    "ERA5_SINGLE_LEVEL_VARIABLES",
-    "ERA5_VARIABLES",
-    "ERA5_PRESSURE_LEVELS",
 ]
 __version__ = version(__name__)

--- a/src/dmd_era5/config_parser.py
+++ b/src/dmd_era5/config_parser.py
@@ -2,6 +2,11 @@ import os
 from datetime import datetime, timedelta
 from logging import Logger
 
+from dmd_era5.constants import (
+    ERA5_PRESSURE_LEVEL_VARIABLES,
+    ERA5_SINGLE_LEVEL_VARIABLES,
+)
+
 
 def validate_time_parameters(parsed_config: dict) -> None:
     """
@@ -123,12 +128,22 @@ def config_parser(config: dict, section: str, logger: Logger | None = None) -> d
 
     # Parse the variables
     try:
-        if config["variables"] == "all":
-            parsed_config["variables"] = ["all"]
+        if config["variables"] == "all_pressure_level_vars":
+            parsed_config["variables"] = list(ERA5_PRESSURE_LEVEL_VARIABLES)
+        elif config["variables"] == "all_single_level_vars":
+            msg = "Single level variables not currently supported."
+            raise ValueError(msg)
         else:
             parsed_config["variables"] = [
                 v.strip() for v in config["variables"].split(",")
             ]
+            for var in parsed_config["variables"]:
+                if var in ERA5_SINGLE_LEVEL_VARIABLES:
+                    msg = f"Single level variables not currently supported: {var}"
+                    raise ValueError(msg)
+                if var not in ERA5_PRESSURE_LEVEL_VARIABLES:
+                    msg = f"Unsupported variable in config: {var}"
+                    raise ValueError(msg)
     except ValueError as e:
         msg = f"Error parsing variables from config: {e}"
         if logger is not None:

--- a/src/dmd_era5/config_parser.py
+++ b/src/dmd_era5/config_parser.py
@@ -4,6 +4,7 @@ from logging import Logger
 
 from dmd_era5.constants import (
     ERA5_PRESSURE_LEVEL_VARIABLES,
+    ERA5_PRESSURE_LEVELS,
     ERA5_SINGLE_LEVEL_VARIABLES,
 )
 
@@ -153,11 +154,15 @@ def config_parser(config: dict, section: str, logger: Logger | None = None) -> d
     # Parse the levels
     try:
         if config["levels"] == "all":
-            parsed_config["levels"] = ["all"]
+            parsed_config["levels"] = list(ERA5_PRESSURE_LEVELS)
         else:
             parsed_config["levels"] = [
                 int(level) for level in config["levels"].split(",")
             ]
+            for level in parsed_config["levels"]:
+                if level not in ERA5_PRESSURE_LEVELS:
+                    msg = f"Unsupported level in config: {level}"
+                    raise ValueError(msg)
     except ValueError as e:
         msg = f"Error parsing levels from config: {e}"
         if logger is not None:

--- a/src/dmd_era5/constants.py
+++ b/src/dmd_era5/constants.py
@@ -1,0 +1,17 @@
+"""
+A module for constants.
+"""
+
+ERA5_PRESSURE_LEVEL_VARIABLES: set[str] = {
+    "temperature",
+    "u_component_of_wind",
+    "v_component_of_wind",
+}
+
+ERA5_SINGLE_LEVEL_VARIABLES: set[str] = {
+    "2m_temperature",
+    "10m_u_component_of_wind",
+    "10m_v_component_of_wind",
+}
+
+ERA5_VARIABLES = ERA5_PRESSURE_LEVEL_VARIABLES.union(ERA5_SINGLE_LEVEL_VARIABLES)

--- a/src/dmd_era5/constants.py
+++ b/src/dmd_era5/constants.py
@@ -15,3 +15,20 @@ ERA5_SINGLE_LEVEL_VARIABLES: set[str] = {
 }
 
 ERA5_VARIABLES = ERA5_PRESSURE_LEVEL_VARIABLES.union(ERA5_SINGLE_LEVEL_VARIABLES)
+
+
+ERA5_PRESSURE_LEVELS: set[int] = {
+    50,
+    100,
+    150,
+    200,
+    250,
+    300,
+    400,
+    500,
+    600,
+    700,
+    850,
+    925,
+    1000,
+}

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -73,9 +73,7 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
             full_era5_ds = create_mock_era5(
                 start_datetime=parsed_config["start_datetime"],
                 end_datetime=parsed_config["end_datetime"],
-                variables=parsed_config["variables"]
-                if parsed_config["variables"] != ["all"]
-                else ["temperature", "u_component_of_wind", "v_component_of_wind"],
+                variables=parsed_config["variables"],
                 levels=parsed_config["levels"],
             )
 
@@ -91,8 +89,7 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
             log_and_print(logger, "ERA5 loaded.")
 
             # Select the variables
-            if parsed_config["variables"] != ["all"]:
-                full_era5_ds = full_era5_ds[parsed_config["variables"]]
+            full_era5_ds = full_era5_ds[parsed_config["variables"]]
 
         # Selecting the time range and levels
         log_and_print(logger, "Slicing ERA5 Dataset...")

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -93,8 +93,6 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
 
         # Selecting the time range and levels
         log_and_print(logger, "Slicing ERA5 Dataset...")
-        if parsed_config["levels"] == ["all"]:
-            parsed_config["levels"] = full_era5_ds.level.values.tolist()
         era5_ds = slice_era5_dataset(
             full_era5_ds,
             parsed_config["start_datetime"],

--- a/tests/test_00_config_parser.py
+++ b/tests/test_00_config_parser.py
@@ -16,7 +16,7 @@ def base_config():
         "start_datetime": "2019-01-01T00",
         "end_datetime": "2020-01-01T00",
         "delta_time": "1y",
-        "variables": "all",
+        "variables": "all_pressure_level_vars",
         "levels": "1000",
         "save_name": "",
     }

--- a/tests/test_03_era5_download.py
+++ b/tests/test_03_era5_download.py
@@ -125,6 +125,14 @@ def test_config_parser_variables(base_config, variables, expected):
     ), f"Expected variables to be {expected}, but got {parsed_config['variables']}"
 
 
+# Test the case where the variables are not valid
+def test_config_parser_variables_invalid(base_config):
+    """Test the variables field with an invalid value."""
+    base_config["variables"] = "temperature,wind"
+    with pytest.raises(ValueError, match="Unsupported variable"):
+        config_parser(base_config, section="era5-download")
+
+
 def test_config_parser_generate_save_name(base_config):
     """Test that the save_name is correctly generated."""
     base_config["start_datetime"] = "2023-01-01"

--- a/tests/test_03_era5_download.py
+++ b/tests/test_03_era5_download.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 
 from dmd_era5 import config_parser
-from dmd_era5.constants import ERA5_PRESSURE_LEVEL_VARIABLES
+from dmd_era5.constants import ERA5_PRESSURE_LEVEL_VARIABLES, ERA5_PRESSURE_LEVELS
 from dmd_era5.era5_download import download_era5_data
 
 
@@ -84,6 +84,7 @@ def test_config_parser_missing_field(base_config, field):
         ("1000,850,500", [1000, 850, 500]),
         ("1000", [1000]),
         (" 1000 , 850 ", [1000, 850]),
+        ("all", list(ERA5_PRESSURE_LEVELS)),
     ],
 )
 def test_config_parser_levels(base_config, levels, expected):

--- a/tests/test_03_era5_download.py
+++ b/tests/test_03_era5_download.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 
 from dmd_era5 import config_parser
+from dmd_era5.constants import ERA5_PRESSURE_LEVEL_VARIABLES
 from dmd_era5.era5_download import download_era5_data
 
 
@@ -18,7 +19,7 @@ def base_config():
         "start_datetime": "2019-01-01T00",
         "end_datetime": "2020-01-01T00",
         "delta_time": "1y",
-        "variables": "all",
+        "variables": "all_pressure_level_vars",
         "levels": "1000",
     }
 
@@ -41,9 +42,10 @@ def test_config_parser_basic(base_config):
     assert parsed_config["delta_time"] == timedelta(
         days=365
     ), f"delta_time should be {timedelta(hours=1)} not {parsed_config['delta_time']}"
-    assert parsed_config["variables"] == [
-        "all"
-    ], f"variables should be ['all'] not {parsed_config['variables']}"
+    assert parsed_config["variables"] == list(ERA5_PRESSURE_LEVEL_VARIABLES), f"""
+    variables should be {list(ERA5_PRESSURE_LEVEL_VARIABLES)}
+    not {parsed_config['variables']}
+    """
     assert parsed_config["levels"] == [
         1000
     ], f"levels should be [1000] not {parsed_config['levels']}"
@@ -97,9 +99,12 @@ def test_config_parser_levels(base_config, levels, expected):
 @pytest.mark.parametrize(
     ("variables", "expected"),
     [
-        ("temperature,humidity,pressure", ["temperature", "humidity", "pressure"]),
-        ("all", ["all"]),
-        (" temperature , humidity ", ["temperature", "humidity"]),
+        (
+            "temperature,u_component_of_wind,v_component_of_wind",
+            ["temperature", "u_component_of_wind", "v_component_of_wind"],
+        ),
+        ("all_pressure_level_vars", list(ERA5_PRESSURE_LEVEL_VARIABLES)),
+        (" temperature , u_component_of_wind ", ["temperature", "u_component_of_wind"]),
     ],
 )
 def test_config_parser_variables(base_config, variables, expected):

--- a/tests/test_03_era5_download.py
+++ b/tests/test_03_era5_download.py
@@ -96,6 +96,14 @@ def test_config_parser_levels(base_config, levels, expected):
     ), f"Expected levels to be {expected}, but got {parsed_config['levels']}"
 
 
+# Test the case where the levels are not valid
+def test_config_parser_levels_invalid(base_config):
+    """Test the levels field with an invalid value."""
+    base_config["levels"] = "965"
+    with pytest.raises(ValueError, match="Unsupported level"):
+        config_parser(base_config, section="era5-download")
+
+
 # --- Test the variables field
 @pytest.mark.parametrize(
     ("variables", "expected"),

--- a/tests/test_04_dvc.py
+++ b/tests/test_04_dvc.py
@@ -47,7 +47,7 @@ def era5_data_config_a(base_config):
 def era5_data_config_b(base_config):
     config = base_config.copy()
     config["variables"] = "u_component_of_wind"
-    config["levels"] = "900"
+    config["levels"] = "850"
     return config
 
 
@@ -55,7 +55,7 @@ def era5_data_config_b(base_config):
 def era5_data_config_c(base_config):
     config = base_config.copy()
     config["variables"] = "temperature,v_component_of_wind"
-    config["levels"] = "800,700"
+    config["levels"] = "1000,925"
     return config
 
 
@@ -294,8 +294,8 @@ def test_main_era5_download(config, request):
                 data_vars[0] == "u_component_of_wind"
             ), "The data should contain u-wind data"
             assert (
-                levels[0] == 900
-            ), "The data should contain data at pressure level 900"
+                levels[0] == 850
+            ), "The data should contain data at pressure level 850"
 
         # Git restore the DVC file, which will have been checked out
         # by when retrieving data from DVC. The DVC log should not be changed.
@@ -366,4 +366,4 @@ def test_dvc_retrieval_from_remote(era5_data_config_b):
     data.close()
 
     assert sorted(data_vars) == ["u_component_of_wind"]
-    assert sorted(levels) == [900]
+    assert sorted(levels) == [850]


### PR DESCRIPTION
This pull request includes significant updates to the configuration and validation of ERA5 data downloads. The changes focus on improving the handling of variables and pressure levels, updating the configuration parsing logic, and adding new constants. Additionally, several tests have been updated to reflect these changes.

Previously, the package wasn't checking whether a variable or pressure level requested by the user existed on ERA5, hence the creation of a `constants.py` module defining these. Also, because ERA5 contains both pressure level and surface level variables, these should be handled differently (the surface level variables don't have an associated `level` dimension). For the time being, let's focus on handling pressure level variables and will update the relevant functions to get surface level variables to work in the future. 

### Configuration and Validation Updates:

* [`config.ini`](diffhunk://#diff-0795adfe01df662f6a34b421a29ee3c5f05389a705da6a791126c6f916701da7L26-R41): Updated the list of supported variables and pressure levels, and clarified that single level and pressure level variables cannot be mixed in the same download.

* [`src/dmd_era5/config_parser.py`](diffhunk://#diff-5adb5891e8af8cd4db4e54314f9dd9b429bbf5245a3b8fcbacd2bd7ffc876f10L126-R147): Modified the `config_parser` function to handle `all_pressure_level_vars` and `all_single_level_vars`, and added validation to ensure only supported variables and levels are used. [[1]](diffhunk://#diff-5adb5891e8af8cd4db4e54314f9dd9b429bbf5245a3b8fcbacd2bd7ffc876f10L126-R147) [[2]](diffhunk://#diff-5adb5891e8af8cd4db4e54314f9dd9b429bbf5245a3b8fcbacd2bd7ffc876f10L141-R165)

### New Constants:

* [`src/dmd_era5/constants.py`](diffhunk://#diff-fc4055be4082f5645e50ed626fd684334feb551479293c475da1ef74d2d09426R1-R34): Introduced new constants for ERA5 pressure level variables, single level variables, and pressure levels.

### Codebase Simplification:

* [`src/dmd_era5/era5_download/era5_download.py`](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L76-R76): Simplified the logic for selecting variables and levels in the `download_era5_data` function. [[1]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L76-R76) [[2]](diffhunk://#diff-0413ed0884123953dfa030a60391d1632428a27d8881a83f54e026cab5e619b0L94-L100)

### Test Updates:

* `tests/test_00_config_parser.py`, `tests/test_03_era5_download.py`, `tests/test_04_dvc.py`: Updated tests to reflect the changes in variable and level handling, and added new test cases for invalid configurations. [[1]](diffhunk://#diff-41a81205df080a7624bb525d1914019f7f5ac01076218b742dd394e620cbdf61L19-R19) [[2]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9R11) [[3]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9L21-R22) [[4]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9L44-R48) [[5]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9R87) [[6]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9R99-R116) [[7]](diffhunk://#diff-a2672d699c67ea515e97f5ab949ecfc9fcaa5a696de5bb7d810a49b185db56a9R128-R135) [[8]](diffhunk://#diff-dfca28cb8993e138f9c618854e6da68711cb6094adabc25aa633a9069ad321f8L50-R58) [[9]](diffhunk://#diff-dfca28cb8993e138f9c618854e6da68711cb6094adabc25aa633a9069ad321f8L297-R298) [[10]](diffhunk://#diff-dfca28cb8993e138f9c618854e6da68711cb6094adabc25aa633a9069ad321f8L369-R369)
