### PR TITLE
Use dask with chunking to open ERA5 dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = ["xarray",
     "pyprojroot",
     "dvc",
     "GitPython",
+    "dask",
     ]
 
 [project.optional-dependencies]

--- a/src/dmd_era5/era5_download/era5_download.py
+++ b/src/dmd_era5/era5_download/era5_download.py
@@ -78,7 +78,9 @@ def download_era5_data(parsed_config: dict, use_mock_data: bool = False) -> xr.D
         else:
             # Open the ERA5 Dataset
             log_and_print(logger, "Loading ERA5 Dataset...")
-            full_era5_ds = xr.open_dataset(parsed_config["source_path"], engine="zarr")
+            full_era5_ds = xr.open_zarr(
+                parsed_config["source_path"], chunks={"time": 100}
+            )
             log_and_print(logger, "ERA5 loaded.")
 
             # Select the variables


### PR DESCRIPTION
If you don't chunk the dataset when you open it, at writing time it typically runs out of memory for a large dataset. Chunking the dataset avoids this problem because the data is written chunk by chunk. I have hard coded the chunking to 100 snapshots along the time dimension, which might not be the best possible strategy in some scenarios, but should generally work well.